### PR TITLE
Patch fix master

### DIFF
--- a/WatsonQueryingService/WatsonQueryingService.js
+++ b/WatsonQueryingService/WatsonQueryingService.js
@@ -47,7 +47,7 @@ function WatsonQueryingService(){
         
     }
     
-    const discoveryService = Config.discoveryService;
+    const discoveryService = Config.getNewDiscoveryService();
     
     this.queryCollection = function(){
 

--- a/config.js
+++ b/config.js
@@ -13,13 +13,16 @@ const Configuration = {
 	apikey: '9U_r_MDwsKMpLghmLBgihOMuFJ0-c-NB3SfFZq3PF63H',
 	serviceURL: 'https://api.us-south.discovery.watson.cloud.ibm.com/instances/aafddb55-662a-48d2-9e31-f69eb609386f',
 	version: '2019-04-30',
-	discoveryService: () => {
+	/*
+		returns a new DiscoveryV1 object configured with the current apiKey and serviceUrl
+	 */
+	getNewDiscoveryService: () => {
 		return new DiscoveryV1({
-	        version: this.version,
+	        version: Configuration.version,
 	        authenticator: new IamAuthenticator({
-	            apikey: this.apikey,
+	            apikey: Configuration.apikey,
 	        }),
-	        url: this.serviceURL,
+	        url: Configuration.serviceURL,
 	    });
 	},
 	PREFERENCE_OPTIONS: {
@@ -27,15 +30,13 @@ const Configuration = {
 		GENRE: 1,
 		EMOTION: 2 
 	},
-
 	QUESTION_FORMATS: {
 		TERNARY: 0,
 		SLIDER: 1,
 		MULTI: 2,
 		RECOMMENDATION: 10
 	},
-
-	RECOMMENDATION_THRESHOLD: 2,
+	RECOMMENDATION_THRESHOLD: 2
 };
 
 module.exports = Configuration; // make importable

--- a/config.js
+++ b/config.js
@@ -6,15 +6,14 @@ const DiscoveryV1 = require('ibm-watson/discovery/v1');
 const {IamAuthenticator} = require('ibm-watson/auth');
 
 
-class Configuration{
-	
-	static environment_id = "0235fa72-912f-4f3d-a606-bb40a3643e40";
-	static pdf_collection_id = "5ee93bfe-ad6b-4928-9616-3df44af86c86";
-	static json_collection_id = "74ac3aaa-a930-4def-aea5-ee01aa6ecaf3";
-	static apikey = '9U_r_MDwsKMpLghmLBgihOMuFJ0-c-NB3SfFZq3PF63H';
-	static serviceURL = 'https://api.us-south.discovery.watson.cloud.ibm.com/instances/aafddb55-662a-48d2-9e31-f69eb609386f';
-	static version = '2019-04-30';
-	static get discoveryService() {
+const Configuration = {
+	environment_id: "0235fa72-912f-4f3d-a606-bb40a3643e40",
+	pdf_collection_id: "5ee93bfe-ad6b-4928-9616-3df44af86c86",
+	json_collection_id: "74ac3aaa-a930-4def-aea5-ee01aa6ecaf3",
+	apikey: '9U_r_MDwsKMpLghmLBgihOMuFJ0-c-NB3SfFZq3PF63H',
+	serviceURL: 'https://api.us-south.discovery.watson.cloud.ibm.com/instances/aafddb55-662a-48d2-9e31-f69eb609386f',
+	version: '2019-04-30',
+	discoveryService: () => {
 		return new DiscoveryV1({
 	        version: this.version,
 	        authenticator: new IamAuthenticator({
@@ -22,21 +21,21 @@ class Configuration{
 	        }),
 	        url: this.serviceURL,
 	    });
-	}
-	static PREFERENCE_OPTIONS = {
+	},
+	PREFERENCE_OPTIONS: {
 		CATEGORY: 0,
 		GENRE: 1,
 		EMOTION: 2 
-	};
+	},
 
-	static QUESTION_FORMATS = {
+	QUESTION_FORMATS: {
 		TERNARY: 0,
 		SLIDER: 1,
 		MULTI: 2,
 		RECOMMENDATION: 10
-	}
+	},
 
-	static RECOMMENDATION_THRESHOLD = 2;
-}
+	RECOMMENDATION_THRESHOLD: 2,
+};
 
 module.exports = Configuration; // make importable


### PR DESCRIPTION
This is a fix to the most current version of master, which is down. The config object being a class was creating problems. This class has been changed to an object literal. The get method `discoveryService` was changed to a property of the object called `getNewDiscoveryService` which must be called as a function to generate a new discovery query object.